### PR TITLE
Implement admin user simulation toggle

### DIFF
--- a/main.py
+++ b/main.py
@@ -2093,6 +2093,23 @@ def handle_forwarded(message):
     channel_id = message.forward_from_chat.id
     bot.reply_to(message, f"ID канала: {channel_id}")
 
+# Команда для переключения режима администратора
+@bot.message_handler(commands=['user_mode'])
+def toggle_user_mode(message):
+    ADMIN_IDS = [376068212, 827743984]
+    if message.from_user.id not in ADMIN_IDS:
+        return
+
+    user_id = message.from_user.id
+    current_mode = user_states.get(user_id, "admin")
+
+    if current_mode == "user_simulation":
+        user_states.pop(user_id, None)
+        bot.reply_to(message, "🔧 Админ-режим включен")
+    else:
+        user_states[user_id] = "user_simulation"
+        bot.reply_to(message, "👤 Пользовательский режим включен\n\nТеперь можете тестировать SmartHandler")
+
 # @bot.message_handler(func=lambda message: True)
 # def handle_all_messages(message):
 #     """Обработка всех остальных сообщений"""

--- a/smart_handler.py
+++ b/smart_handler.py
@@ -120,11 +120,21 @@ class SmartHandler:
 
     def handle_message(self, message):
         """Основная функция - обрабатываем сообщение пользователя"""
-        # ✅ ДОБАВИТЬ ЭТУ ПРОВЕРКУ:
         ADMIN_IDS = [376068212, 827743984]
-        if message.from_user.id in ADMIN_IDS:
-            print(f"[SMART] Пропускаю админа {message.from_user.id}")
-            return  # НЕ ОБРАБАТЫВАЕМ СООБЩЕНИЯ ОТ АДМИНОВ
+
+        # ✅ НОВАЯ ЛОГИКА: проверяем режим админа
+        user_id = message.from_user.id
+        if user_id in ADMIN_IDS:
+            # Импортируем из main.py текущее состояние
+            import main
+            admin_mode = main.user_states.get(user_id)
+
+            if admin_mode != "user_simulation":
+                print(f"[SMART] Пропускаю админа {user_id} (админ-режим)")
+                return
+            else:
+                print(f"[SMART] Админ {user_id} в пользовательском режиме")
+
         # 1. Анализируем сообщение
         category = self.analyze_message(message.text)
         


### PR DESCRIPTION
## Summary
- add `/user_mode` command to switch admin messages between admin and user modes
- update smart handler to consider the admin mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_6849b0384d98832bab8bf7861113d66c